### PR TITLE
Add LICENSE to the published archive in stable-linux workflow

### DIFF
--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -94,10 +94,13 @@ jobs:
           SHOULD_BUILD_REH_WEB: 'no'
         run: ./build.sh
 
+      - name: Copy LICENSE file
+        run: cp LICENSE vscode/
+
       - name: Compress vscode artifact
         run: |
           find vscode -type f -not -path "*/node_modules/*" -not -path "vscode/.build/node/*" -not -path "vscode/.git/*" > vscode.txt
-          # echo "vscode/.build/extensions/node_modules" >> vscode.txt
+          echo "vscode/LICENSE" >> vscode.txt
           echo "vscode/.git" >> vscode.txt
           tar -czf vscode.tar.gz -T vscode.txt
 

--- a/package_linux_reh.sh
+++ b/package_linux_reh.sh
@@ -160,6 +160,9 @@ echo "Building REH"
 # yarn gulp "vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}-min-ci"
 yarn gulp "vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
 
+# Add LICENSE file to vscode-reh directory
+cp ../LICENSE .
+
 # EXPECTED_GLIBC_VERSION="${GLIBC_VERSION}" EXPECTED_GLIBCXX_VERSION="${GLIBCXX_VERSION}" SEARCH_PATH="../vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}" ./build/azure-pipelines/linux/verify-glibc-requirements.sh
 
 pushd "../vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
@@ -177,6 +180,9 @@ echo "Building REH-web"
 # yarn gulp minify-vscode-reh-web
 # yarn gulp "vscode-reh-web-${VSCODE_PLATFORM}-${VSCODE_ARCH}-min-ci"
 yarn gulp "vscode-reh-web-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
+
+# Add LICENSE file to vscode-reh-web directory
+cp ../LICENSE .
 
 # EXPECTED_GLIBC_VERSION="${GLIBC_VERSION}" EXPECTED_GLIBCXX_VERSION="${GLIBCXX_VERSION}" SEARCH_PATH="../vscode-reh-web-${VSCODE_PLATFORM}-${VSCODE_ARCH}" ./build/azure-pipelines/linux/verify-glibc-requirements.sh
 

--- a/package_web.sh
+++ b/package_web.sh
@@ -47,6 +47,7 @@ done
 echo "Building WEB"
 yarn gulp vscode-web
 
+cp ../LICENSE .
 pushd "../vscode-web"
 
 echo "Archiving WEB"


### PR DESCRIPTION
Add LICENSE file to the published archive in the stable-linux workflow.

* **.github/workflows/stable-linux.yml**
  - Add a step to copy the LICENSE file to the vscode directory before compressing the artifact.
  - Update the tar command to include the LICENSE file in the vscode.tar.gz file.

* **package_linux_reh.sh**
  - Add a step to copy the LICENSE file to the vscode-reh directory before compressing the artifact.
  - Add a step to copy the LICENSE file to the vscode-reh-web directory before compressing the artifact.

* **package_web.sh**
  - Add a step to copy the LICENSE file to the vscode-web directory before compressing the artifact.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/vscodium/pull/2?shareId=12777020-dab2-48e0-b038-88fb2b2d79f0).