### PR TITLE
Add safe directory step to stable-linux GitHub Actions workflows

### DIFF
--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           ref: ${{ env.GITHUB_BRANCH }}
 
+      - name: Set safe directory
+        run: git config --global --add safe.directory ${{ github.workspace }}
+
       - name: Switch to relevant branch
         env:
           PULL_REQUEST_ID: ${{ github.event.inputs.checkout_pr }}
@@ -79,6 +82,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_BRANCH }}
+
+      - name: Set safe directory
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Switch to relevant branch
         env:
@@ -136,6 +142,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_BRANCH }}
+
+      - name: Set safe directory
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Switch to relevant branch
         env:
@@ -196,6 +205,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_BRANCH }}
+
+      - name: Set safe directory
+        run: git config --global --add safe.directory ${{ github.workspace }}
 
       - name: Switch to relevant branch
         env:


### PR DESCRIPTION
Add a step to set the safe directory in the stable-linux GitHub Actions workflows.

* Add a step to set the safe directory in the `check` job.
* Add a step to set the safe directory in the `compile` job.
* Add a step to set the safe directory in the `reh_linux` job.
* Add a step to set the safe directory in the `web` job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/vscodium/pull/3?shareId=53059103-83f5-4f17-8b51-31891a2c6d4a).